### PR TITLE
Add license tag to the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "design-system",
   "version": "0.9.1",
+  "license" : "BSD-2-Clause",
   "description": "Salesforce Lightning Design System",
   "scripts": {
     "postinstall": "./scripts/npm/postinstall.sh",


### PR DESCRIPTION
to get rid of a silly npm warning.