### PR TITLE
Fixed dropdown

### DIFF
--- a/ui/components/menus/flavors/dropdown/index.scss
+++ b/ui/components/menus/flavors/dropdown/index.scss
@@ -224,7 +224,7 @@
       display: none;
     }
 
-    &.#{$css-prefix}is-open {
+    &.#{$css-prefix}is-open .#{$css-prefix}dropdown {
       display: block;
       visibility: visible;
       opacity: 1;


### PR DESCRIPTION
This fixed dropdown when using .slds-dropdown-trigger--click, if .slds-is-open exists 

the correct css is:

```css
&.#{$css-prefix}is-open .#{$css-prefix}dropdown {
      display: block;
      visibility: visible;
      opacity: 1;
}
```