### PR TITLE
Better select styles for Firefox and Safari

### DIFF
--- a/ui/components/forms/flavors/select/index.scss
+++ b/ui/components/forms/flavors/select/index.scss
@@ -21,36 +21,39 @@
       padding: $spacing-x-small;
     }
   }
-}
-
-#{$css-prefix}form-element__select-container {
+  
+  &__container {
     position: relative;
+
     .#{$css-prefix}select {
-        -moz-appearance: none;
-        -webkit-appearance: none;
-        appearance: none;
-        padding-left: $spacing-x-small;
+      -moz-appearance: none;
+      -webkit-appearance: none;
+      padding: {
+        left: $spacing-x-small;
+        right: $spacing-large;
+      }
     }
-    
+
     &:before,
     &:after {
-        position: absolute;
-        content: "";
-        display: block;
-        right: 10px;
-        width: 0;
-        height: 0;
-        border-left: 3px solid transparent;
-        border-right: 3px solid transparent;
+      position: absolute;
+      content: "";
+      display: block;
+      right: $spacing-xx-small;
+      width: 0;
+      height: 0;
+      border-left: 3px solid transparent;
+      border-right: 3px solid transparent;
     }
-    
+
     &:before {
-        border-bottom: 5px solid $color-background-inverse;
-        top: 10px;
+      border-bottom: 5px solid $color-background-inverse;
+      top: calc((#{$line-height-button} / 2) - 6px);
     }
-    
+
     &:after {
-        border-top: 5px solid $color-background-inverse;
-        bottom: 10px;
+      border-top: 5px solid $color-background-inverse;
+      bottom: calc((#{$line-height-button} / 2) - 6px);
     }
+  }
 }

--- a/ui/components/forms/flavors/select/index.scss
+++ b/ui/components/forms/flavors/select/index.scss
@@ -22,3 +22,35 @@
     }
   }
 }
+
+#{$css-prefix}form-element__select-container {
+    position: relative;
+    .#{$css-prefix}select {
+        -moz-appearance: none;
+        -webkit-appearance: none;
+        appearance: none;
+        padding-left: $spacing-x-small;
+    }
+    
+    &:before,
+    &:after {
+        position: absolute;
+        content: "";
+        display: block;
+        right: 10px;
+        width: 0;
+        height: 0;
+        border-left: 3px solid transparent;
+        border-right: 3px solid transparent;
+    }
+    
+    &:before {
+        border-bottom: 5px solid $color-background-inverse;
+        top: 10px;
+    }
+    
+    &:after {
+        border-top: 5px solid $color-background-inverse;
+        bottom: 10px;
+    }
+}

--- a/ui/components/forms/flavors/select/index.scss
+++ b/ui/components/forms/flavors/select/index.scss
@@ -39,7 +39,7 @@
       position: absolute;
       content: "";
       display: block;
-      right: $spacing-xx-small;
+      right: $spacing-x-small;
       width: 0;
       height: 0;
       border-left: 3px solid transparent;

--- a/ui/components/forms/flavors/select/index.scss
+++ b/ui/components/forms/flavors/select/index.scss
@@ -22,3 +22,35 @@
     }
   }
 }
+
+.#{$css-prefix}form-element__select-container {
+    position: relative;
+    .#{$css-prefix}select {
+        -moz-appearance: none;
+        -webkit-appearance: none;
+        appearance: none;
+        padding-left: $spacing-x-small;
+    }
+    
+    &:before,
+    &:after {
+        position: absolute;
+        content: "";
+        display: block;
+        right: 10px;
+        width: 0;
+        height: 0;
+        border-left: 3px solid transparent;
+        border-right: 3px solid transparent;
+    }
+    
+    &:before {
+        border-bottom: 5px solid $color-background-inverse;
+        top: 10px;
+    }
+    
+    &:after {
+        border-top: 5px solid $color-background-inverse;
+        bottom: 10px;
+    }
+}

--- a/ui/components/forms/flavors/select/index.scss
+++ b/ui/components/forms/flavors/select/index.scss
@@ -22,35 +22,3 @@
     }
   }
 }
-
-.#{$css-prefix}form-element__select-container {
-    position: relative;
-    .#{$css-prefix}select {
-        -moz-appearance: none;
-        -webkit-appearance: none;
-        appearance: none;
-        padding-left: $spacing-x-small;
-    }
-    
-    &:before,
-    &:after {
-        position: absolute;
-        content: "";
-        display: block;
-        right: 10px;
-        width: 0;
-        height: 0;
-        border-left: 3px solid transparent;
-        border-right: 3px solid transparent;
-    }
-    
-    &:before {
-        border-bottom: 5px solid $color-background-inverse;
-        top: 10px;
-    }
-    
-    &:after {
-        border-top: 5px solid $color-background-inverse;
-        bottom: 10px;
-    }
-}

--- a/ui/components/forms/flavors/select/index.scss
+++ b/ui/components/forms/flavors/select/index.scss
@@ -22,7 +22,7 @@
     }
   }
   
-  &__container {
+  &_container {
     position: relative;
 
     .#{$css-prefix}select {
@@ -32,6 +32,10 @@
         left: $spacing-x-small;
         right: $spacing-large;
       }
+    }
+
+    &::-ms-expand {
+      display: none;
     }
 
     &:before,


### PR DESCRIPTION
This is my suggested fix to overriding any `<select>` styles enforced by the browser. The div with `.slds-form-element__control` can also have `.slds-form-element__select-container` to set the select's appearance to none, and add proper padding and pseudo elements for create the drop-down arrows.