### PR TITLE
Fix usage of class and containerClass attributes

### DIFF
--- a/site/resources/lightning-svg-icon-component-helper/index.jsx
+++ b/site/resources/lightning-svg-icon-component-helper/index.jsx
@@ -87,17 +87,18 @@ export default (
     var size = component.get("v.size");
     var name = component.get("v.name");
     var classname = component.get("v.class");
+    var containerclass = component.get("v.containerClass");
     var category = component.get("v.category");
 
     var containerClassName = [
         prefix+"icon__container",
         prefix+"icon-"+category+"-"+name,
-        classname
+        containerclass
         ].join(' ');
-    var iconClassName = prefix+"icon "+prefix+"icon--" + size;
     component.set("v.containerClass", containerClassName);
 
     var svgroot = document.createElementNS(svgns, "svg");
+    var iconClassName = prefix+"icon "+prefix+"icon--" + size+" "+classname;
     svgroot.setAttribute("aria-hidden", "true");
     svgroot.setAttribute("class", iconClassName);
     svgroot.setAttribute("name", name);


### PR DESCRIPTION
I noticed earlier when using the Lightning SVG Icon Component Helper that the `slds-icon-text-default` class wasn't being applied to the `svg` element: it turns out the reason is that the `class` attribute was being added to the container (instead of the `containerClass` attribute), and nothing was being added to the `svg` element.

This change fixes this issue by getting the `containerClass` attribute and setting that on the container, and then adding the `class` attribute to the `svg`.