### PR TITLE
Fix bug for <legend> in Visualforce specific styles

### DIFF
--- a/ui/core/_core-vf.scss
+++ b/ui/core/_core-vf.scss
@@ -39,3 +39,7 @@ h6 {
 li {
   margin-left: 0; // TODO: To override core.css - enough?
 }
+
+fieldset legend {
+  font-weight: normal;
+}


### PR DESCRIPTION
Changes proposed in this PR:
- Fix bug for `<legend>` in Visualforce styles. The legend is bold in Visualforce, but it shouldn't be:

![selection_306](https://cloud.githubusercontent.com/assets/973711/15209069/5f8d124a-182f-11e6-8f79-b7d42184a1f3.png)

## Preview:
> ![selection_305](https://cloud.githubusercontent.com/assets/973711/15209125/bd3afc7c-182f-11e6-95d9-b18ba70c40ba.png)