### PR TITLE
Support slds-min-<SIZE>-hide (#263) and fix slds-max-<SIZE>-hide to work according to table in docs

### DIFF
--- a/ui/dependencies/_layout.scss
+++ b/ui/dependencies/_layout.scss
@@ -364,17 +364,15 @@
       }
     }
   }
-  @if $max {
+
+  @if $min {
 
     .#{$css-prefix}max-#{$class-name}-hide {
 
-      @media (max-width: $max - 1) {
+      @media (max-width: $min - 1) {
         display: none;
       }
     }
-  }
-
-  @if $min {
 
     .#{$css-prefix}min-#{$class-name}-hide {
 

--- a/ui/dependencies/_layout.scss
+++ b/ui/dependencies/_layout.scss
@@ -373,6 +373,19 @@
       }
     }
   }
+  .#{$css-prefix}max-#{$class-name}-show {
+
+    @media (max-width: $min - 1) {
+      display: block;
+
+      &--inline-block {
+        display: inline-block;
+      }
+      &--inline {
+        display: inline;
+      }
+    }
+  }
 }
 
 @mixin align-horizontal($children: null, $fallback: null, $mq: null) {

--- a/ui/dependencies/_layout.scss
+++ b/ui/dependencies/_layout.scss
@@ -373,16 +373,13 @@
       }
     }
   }
-  .#{$css-prefix}max-#{$class-name}-show {
 
-    @media (max-width: $min - 1) {
-      display: block;
+  @if $min {
 
-      &--inline-block {
-        display: inline-block;
-      }
-      &--inline {
-        display: inline;
+    .#{$css-prefix}min-#{$class-name}-hide {
+
+      @media (min-width: $min) {
+        display: none;
       }
     }
   }

--- a/ui/utilities/visibility/flavors/responsive/index.markup.md
+++ b/ui/utilities/visibility/flavors/responsive/index.markup.md
@@ -103,7 +103,7 @@
         <td class="visible">Initial</td>
       </tr>
       <tr>
-        <th><code>.{{cssPrefix}}max-x-small-show</code></th>
+        <th><code>.{{cssPrefix}}min-x-small-hide</code></th>
         <td class="visible">Initial</td>
         <td class="hidden">Hide</td>
         <td class="hidden">Hide</td>
@@ -112,7 +112,7 @@
         <td class="hidden">Hide</td>
       </tr>
       <tr>
-        <th><code>.{{cssPrefix}}max-small-show</code></th>
+        <th><code>.{{cssPrefix}}min-small-hide</code></th>
         <td class="visible">Initial</td>
         <td class="visible">Initial</td>
         <td class="hidden">Hide</td>
@@ -121,7 +121,7 @@
         <td class="hidden">Hide</td>
       </tr>
       <tr>
-        <th><code>.{{cssPrefix}}max-medium-show</code></th>
+        <th><code>.{{cssPrefix}}min-medium-hide</code></th>
         <td class="visible">Initial</td>
         <td class="visible">Initial</td>
         <td class="visible">Initial</td>

--- a/ui/utilities/visibility/flavors/responsive/index.markup.md
+++ b/ui/utilities/visibility/flavors/responsive/index.markup.md
@@ -102,6 +102,33 @@
         <td class="visible">Initial</td>
         <td class="visible">Initial</td>
       </tr>
+      <tr>
+        <th><code>.{{cssPrefix}}max-x-small-show</code></th>
+        <td class="visible">Initial</td>
+        <td class="hidden">Hide</td>
+        <td class="hidden">Hide</td>
+        <td class="hidden">Hide</td>
+        <td class="hidden">Hide</td>
+        <td class="hidden">Hide</td>
+      </tr>
+      <tr>
+        <th><code>.{{cssPrefix}}max-small-show</code></th>
+        <td class="visible">Initial</td>
+        <td class="visible">Initial</td>
+        <td class="hidden">Hide</td>
+        <td class="hidden">Hide</td>
+        <td class="hidden">Hide</td>
+        <td class="hidden">Hide</td>
+      </tr>
+      <tr>
+        <th><code>.{{cssPrefix}}max-medium-show</code></th>
+        <td class="visible">Initial</td>
+        <td class="visible">Initial</td>
+        <td class="visible">Initial</td>
+        <td class="hidden">Hide</td>
+        <td class="hidden">Hide</td>
+        <td class="hidden">Hide</td>
+      </tr>
     </table>
   </div>
 </div>

--- a/ui/utilities/visibility/flavors/responsive/index.markup.md
+++ b/ui/utilities/visibility/flavors/responsive/index.markup.md
@@ -103,6 +103,15 @@
         <td class="visible">Initial</td>
       </tr>
       <tr>
+        <th><code>.{{cssPrefix}}max-large-hide</code></th>
+        <td class="hidden">Hide</td>
+        <td class="hidden">Hide</td>
+        <td class="hidden">Hide</td>
+        <td class="hidden">Hide</td>
+        <td class="visible">Initial</td>
+        <td class="visible">Initial</td>
+      </tr>
+      <tr>
         <th><code>.{{cssPrefix}}min-x-small-hide</code></th>
         <td class="visible">Initial</td>
         <td class="hidden">Hide</td>
@@ -126,6 +135,15 @@
         <td class="visible">Initial</td>
         <td class="visible">Initial</td>
         <td class="hidden">Hide</td>
+        <td class="hidden">Hide</td>
+        <td class="hidden">Hide</td>
+      </tr>
+      <tr>
+        <th><code>.{{cssPrefix}}min-large-hide</code></th>
+        <td class="visible">Initial</td>
+        <td class="visible">Initial</td>
+        <td class="visible">Initial</td>
+        <td class="visible">Initial</td>
         <td class="hidden">Hide</td>
         <td class="hidden">Hide</td>
       </tr>

--- a/ui/utilities/visibility/flavors/responsive/index.react.example.jsx
+++ b/ui/utilities/visibility/flavors/responsive/index.react.example.jsx
@@ -19,18 +19,19 @@ export default (
     <div className={pf('x-small-show')}>Show on 320px and up</div>
     <div className={pf('x-small-show-only')}>Show only between 320px and 479px</div>
     <div className={pf('max-x-small-hide')}>Hide on 319px and down</div>
-    <div className={pf('hide max-x-small-show')}>Hide on 320px and up</div>
+    <div className={pf('min-x-small-hide')}>Hide on 320px and up</div>
 
     <div className={pf('small-show')}>Show on 480px and up</div>
     <div className={pf('small-show-only')}>Show only between 480px and 767px</div>
     <div className={pf('max-small-hide')}>Hide on 479px and down</div>
-    <div className={pf('hide max-small-show')}>Hide on 480px and up</div>
+    <div className={pf('min-small-hide')}>Hide on 480px and up</div>
 
     <div className={pf('medium-show')}>Show on 768px and up</div>
     <div className={pf('medium-show-only')}>Show only between 768px and 1023px</div>
     <div className={pf('max-medium-hide')}>Hide on 1023px and down</div>
-    <div className={pf('hide max-medium-show')}>Hide on 1024px and up</div>
+    <div className={pf('min-medium-hide')}>Hide on 768px and up</div>
 
     <div className={pf('large-show')}>Show on 1024px and up</div>
+    <div className={pf('min-large-hide')}>Hide on 1024px and up</div>
   </div>
 );

--- a/ui/utilities/visibility/flavors/responsive/index.react.example.jsx
+++ b/ui/utilities/visibility/flavors/responsive/index.react.example.jsx
@@ -19,14 +19,17 @@ export default (
     <div className={pf('x-small-show')}>Show on 320px and up</div>
     <div className={pf('x-small-show-only')}>Show only between 320px and 479px</div>
     <div className={pf('max-x-small-hide')}>Hide on 319px and down</div>
+    <div className={pf('hide max-x-small-show')}>Hide on 320px and up</div>
 
     <div className={pf('small-show')}>Show on 480px and up</div>
     <div className={pf('small-show-only')}>Show only between 480px and 767px</div>
     <div className={pf('max-small-hide')}>Hide on 479px and down</div>
+    <div className={pf('hide max-small-show')}>Hide on 480px and up</div>
 
     <div className={pf('medium-show')}>Show on 768px and up</div>
     <div className={pf('medium-show-only')}>Show only between 768px and 1023px</div>
     <div className={pf('max-medium-hide')}>Hide on 1023px and down</div>
+    <div className={pf('hide max-medium-show')}>Hide on 1024px and up</div>
 
     <div className={pf('large-show')}>Show on 1024px and up</div>
   </div>

--- a/ui/utilities/visibility/flavors/responsive/index.react.example.jsx
+++ b/ui/utilities/visibility/flavors/responsive/index.react.example.jsx
@@ -28,10 +28,11 @@ export default (
 
     <div className={pf('medium-show')}>Show on 768px and up</div>
     <div className={pf('medium-show-only')}>Show only between 768px and 1023px</div>
-    <div className={pf('max-medium-hide')}>Hide on 1023px and down</div>
+    <div className={pf('max-medium-hide')}>Hide on 767px and down</div>
     <div className={pf('min-medium-hide')}>Hide on 768px and up</div>
 
     <div className={pf('large-show')}>Show on 1024px and up</div>
+    <div className={pf('max-medium-hide')}>Hide on 1023px and down</div>
     <div className={pf('min-large-hide')}>Hide on 1024px and up</div>
   </div>
 );


### PR DESCRIPTION
Changes proposed in this pull request:
- Add support for hiding elements above certain breakpoints. This aims to be an exact inverse of the `slds-max-<SIZE>-hide` set of classes.
- Fix the `slds-max-<SIZE>-hide` class to work according to the table in the documentation. This was done rather than fixing the documentation to reflect the actual behavior because the behavior described by the documentation seems more straight-forward. For example, currently `slds-max-medium-hide` is actually hidden in the medium range because the `display: none` kicks in at a max-width of 1023px. This contradicts the table below which lists the state in the medium range as "Initial". This may just be personal preference, but I think the classes make sense as the table describes them, where `slds-max-medium-hide` means "Hide this element up to the medium breakpoint" instead of the current "Hide this element up to the large breakpoint".
### Reviewer, please refer to this "definition of done" checklist:
- [ ] Tested on **desktop** (see [supported browsers](https://www.lightningdesignsystem.com/faq/#what-browsers-are-supported))
- [ ] Tested on **mobile** (for responsive or mobile-specific features)
- [ ] Documentation is up to date
- [ ] Release notes mention the changes

⚠️ Once this pull request is merged, please merge the code into other development branches:<br />
[Merge branch 'summer-16' into winter-17](https://github.com/salesforce-ux/design-system-internal/compare/winter-17...summer-16?expand=1&title=Merge branch %27summer-16%27 into winter-17)
