### PR TITLE
Set SvgIcon href without __dangerouslySetInnerHtml

### DIFF
--- a/app_modules/ui/svg-icon/index.jsx
+++ b/app_modules/ui/svg-icon/index.jsx
@@ -18,18 +18,19 @@ class SvgIcon extends React.Component {
     return (
       <svg
         {...rest}
-        aria-hidden={true}
-        dangerouslySetInnerHTML={{__html: this.getUse()}} />
+        aria-hidden={true}>
+        <use xlinkHref={this.getHref()}></use>
+      </svg>
     );
   }
-  getUse() {
+  getHref() {
     if (!(this.props.sprite && this.props.symbol)) {
       return;
     }
 
     const { sprite, symbol } = this.props;
     const href = `/assets/icons/${sprite}-sprite/svg/symbols.svg#${symbol}`;
-    return `<use xlink:href="${href}"></use>`;
+    return href;
   }
 }
 


### PR DESCRIPTION
React 15.x now supports the `xlink:href` SVG attribute (as `xlinkHref`), this means we can now use the `<use>` tag as normal in JSX. `getUse()` now becomes `getHref` and soley returns the href instead of an html string.

Changes proposed in this pull request:

* Replace `__dangerouslySetInnerHtml` with a JSX <`use>` svg tag. 
* getUrl now returns the final `href` only to go into the `<use>` tag in `render()`
* Rename `getUrl` in SvgIcon to `getHref`

### Reviewer, please refer to this "definition of done" checklist:

* [x] Tested on **desktop** (see [supported browsers](https://www.lightningdesignsystem.com/faq/#what-browsers-are-supported))
* [ ] Tested on **mobile** (for responsive or mobile-specific features)
* [x] Confirm **Accessibility**
* [ ] Documentation is up to date
* [ ] Release notes mention the changes

⚠️ Once this pull request is merged, please merge the code into other development branches:
[Merge branch 'winter-17' into spring-17](http://bit.ly/28OZIGM)
[Merge branch 'spring-17' into summer-17](http://bit.ly/2fjT4LY)
