### PR TITLE
Fix gulp lint:spaces warning

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,11 +4,11 @@ External contributors are required to sign a Contributor’s License Agreement.
 You will be prompted to sign it when you open a pull request.
 
 1. Create a new issue before starting your project so that we can keep
-   track of what you are trying to add/fix. That way, we can also offer
-   suggestions or let you know if there is already an effort in progress.
+  track of what you are trying to add/fix. That way, we can also offer
+  suggestions or let you know if there is already an effort in progress.
 2. Fork off this repository.
 3. Create a topic branch for the issue that you are trying to add.
-   When possible, you should branch off the default branch.
+  When possible, you should branch off the default branch.
 4. Edit the code in your fork.
 5. Send us a well documented pull request when you are done.
 


### PR DESCRIPTION
Changes proposed in this pull request:

* Fixed a lint error in CONTRIBUTING.md
  * Expected an indentation at 4 instead of at 3.
* Run `./node_modules/gulp/bin/gulp.js lint:spaces` to verify

### Reviewer, please refer to this "definition of done" checklist:

* [x] Tested on **desktop** (see [supported browsers](https://www.lightningdesignsystem.com/faq/#what-browsers-are-supported))
* [x] Tested on **mobile** (for responsive or mobile-specific features)
* [x] Confirm **Accessibility**
* [x] Documentation is up to date
* [x] Release notes mention the changes

⚠️ Once this pull request is merged, please merge the code into other development branches:
[Merge branch 'winter-17' into spring-17](http://bit.ly/28OZIGM)
[Merge branch 'spring-17' into summer-17](http://bit.ly/2fjT4LY)
