### PR TITLE
Fix slds-size--* classes being overwritten in slds-form--compound by a default 100% width on compound slds-form-elements

### DIFF
--- a/ui/components/forms/flavors/compound-form/_index.scss
+++ b/ui/components/forms/flavors/compound-form/_index.scss
@@ -21,7 +21,10 @@
   }
 
   .slds-form-element {
-    width: 100%; // Default - Stretch 100% unless told otherwise using sizing helpers
+    // Default - Stretch 100% unless told otherwise using sizing helpers
+    &:not([class*="slds-size--"]) {
+      width: 100%;
+    }
 
     + .slds-form-element {
       padding-left: $spacing-x-small;

--- a/ui/components/forms/flavors/compound-form/index.react.example.jsx
+++ b/ui/components/forms/flavors/compound-form/index.react.example.jsx
@@ -34,23 +34,21 @@ export default (
     <legend className="slds-form-element__label slds-text-title--caps">Address</legend>
     <div className="slds-form-element__group">
       <div className="slds-form-element__row">
-        <div className="slds-form-element slds-size--1-of-1">
+        <div className="slds-form-element">
           <label className="slds-form-element__label" htmlFor="input-03">Street</label>
           <input id="input-03" className="slds-input" type="text" />
         </div>
       </div>
       <div className="slds-form-element__row">
-        <div className="slds-form-element slds-size--1-of-2">
+        <div className="slds-form-element slds-size--3-of-5">
           <label className="slds-form-element__label" htmlFor="input-04">City</label>
           <input id="input-04" className="slds-input" type="text" />
         </div>
-        <div className="slds-form-element slds-size--1-of-2">
+        <div className="slds-form-element slds-size--1-of-5">
           <label className="slds-form-element__label" htmlFor="input-05">State</label>
           <input id="input-05" className="slds-input" type="text" />
         </div>
-      </div>
-      <div className="slds-form-element__row">
-        <div className="slds-form-element slds-size--1-of-2">
+        <div className="slds-form-element slds-size--1-of-5">
           <label className="slds-form-element__label" htmlFor="input-06">ZIP Code</label>
           <input id="input-06" className="slds-input" type="text" />
         </div>


### PR DESCRIPTION
The existing styles for form elements within compound forms caused elements to ignore any declared `slds-size` as the specificity for `.slds-form--compound .slds-form-element { width: 100%; }` overwrote the single specificity of `slds-size--*-of-*`.

This fix aims to resolve that by only applying the 100% width to elements lacking a size class as a fallback.

---

Fix resolves existing bugs:

* #262 - _slds-size overridden in Compound Form_ 
* #367 - _bug with slds-size--1-of-2 and slds-form-control_

Changes proposed in this pull request:

* Add `width: 100%` as a fallback to any `slds-form-element` within `slds-form--compound` that *does not* have an `slds-size--*-of-*` class on it.
* Update documentation example as previous version looked correct due to even column widths displaying properly based on flex-containers.

### Reviewer, please refer to this "definition of done" checklist:

* [ ] Tested on **desktop** (see [supported browsers](https://www.lightningdesignsystem.com/faq/#what-browsers-are-supported))
* [ ] Tested on **mobile** (for responsive or mobile-specific features)
* [ ] Confirm **Accessibility**
* [ ] Documentation is up to date
* [ ] Release notes mention the changes

⚠️ Once this pull request is merged, please merge the code into other development branches:
[Merge branch 'winter-17' into spring-17](http://bit.ly/28OZIGM)
[Merge branch 'spring-17' into summer-17](http://bit.ly/2fjT4LY)
