### PR TITLE
Fix slds-icon_container--circle not properly resizing with smaller icons

### DIFF
--- a/ui/components/icons/_index.scss
+++ b/ui/components/icons/_index.scss
@@ -18,6 +18,7 @@
   &--circle {
     padding: $spacing-x-small;
     border-radius: $border-radius-circle;
+    line-height: $line-height-reset;
   }
 }
 

--- a/ui/components/icons/flavors/base/_index.scss
+++ b/ui/components/icons/flavors/base/_index.scss
@@ -18,6 +18,7 @@
   &--circle {
     padding: $spacing-x-small;
     border-radius: $border-radius-circle;
+    line-height: $line-height-reset;
   }
 }
 


### PR DESCRIPTION
Currently, while the icons are set to reset to a line-height of 1, circular containers are inheriting the line-height of `.site` which means at smaller sizes, the circular container will shrink width-wise, but not height-wise.

Currently if you inspect the Action Icon containers in the documentation, their dimensions are 40x41, indicating that from the start they aren't truly circular. Setting the circular containers line-height to match that of their icons means the circular shape will be retained regardless of icon size.

---

Issues this fix resolves:

* #228 - _x-small circle icon has oval shape_

Changes proposed in this pull request:

* Implement a fixed line-height of 1 on circular icon containers to prevent inheritance of `.site` line-height, which causes the circular background to stretch and not properly resize to the dimensions of the icon

### Reviewer, please refer to this "definition of done" checklist:

* [ ] Tested on **desktop** (see [supported browsers](https://www.lightningdesignsystem.com/faq/#what-browsers-are-supported))
* [ ] Tested on **mobile** (for responsive or mobile-specific features)
* [ ] Confirm **Accessibility**
* [ ] Documentation is up to date
* [ ] Release notes mention the changes

⚠️ Once this pull request is merged, please merge the code into other development branches:
[Merge branch 'winter-17' into spring-17](http://bit.ly/28OZIGM)
[Merge branch 'spring-17' into summer-17](http://bit.ly/2fjT4LY)
