### PR TITLE
[FEATURE] Improved Visibility styles for responsive design

### DIFF
--- a/ui/utilities/visibility/flavors/responsive/_index.scss
+++ b/ui/utilities/visibility/flavors/responsive/_index.scss
@@ -16,18 +16,19 @@
 
 // Generates responsive visibility tags
 @each $key, $value in (
-  x-small: $mq-x-small,
-  small: $mq-small,
-  medium: $mq-medium,
-  large: $mq-large,
-  x-large: $mq-x-large,
+  'x-small': $mq-x-small,
+  'small': $mq-small,
+  'medium': $mq-medium,
+  'large': $mq-large,
+  'x-large': $mq-x-large,
 ) {
   @media(min-width: $value) {
     // [EXAMPLE] slds-hide--medium:
     // HIDES the element when window is BIGGER than medium.
     // element will be displayed normaly when window is smaller.
     .slds-hide--#{$key} {
-      display: none;
+      // !important is required to increase specificity
+      display: none!important;
     }
   }
 
@@ -36,7 +37,8 @@
     // HIDES the element when window is SMALLER than medium.
     // element will be displayed normaly when window is bigger.
     .slds-show--#{$key} {
-      display: none;
+      // !important is required to increase specificity
+      display: none!important;
     }
   }
 }

--- a/ui/utilities/visibility/flavors/responsive/_index.scss
+++ b/ui/utilities/visibility/flavors/responsive/_index.scss
@@ -23,16 +23,16 @@
   x-large: $mq-x-large,
 ) {
   @media(min-width: $value) {
-    // [EXAMPLE] hide--medium:
+    // [EXAMPLE] slds-hide--medium:
     // HIDES the element when window is BIGGER than medium.
     // element will be displayed normaly when window is smaller.
-    .hide--#{$key} { display: none; }
+    .slds-hide--#{$key} { display: none; }
   }
 
   @media(max-width: $value - 1px) {
-    // [EXAMPLE] show--medium:
+    // [EXAMPLE] slds-show--medium:
     // HIDES the element when window is SMALLER than medium.
     // element will be displayed normaly when window is bigger.
-    .show--#{$key} { display: none; }
+    .slds-show--#{$key} { display: none; }
   }
 }

--- a/ui/utilities/visibility/flavors/responsive/_index.scss
+++ b/ui/utilities/visibility/flavors/responsive/_index.scss
@@ -13,3 +13,26 @@
 @include visibility(small, $mq-small, $mq-medium);
 @include visibility(medium, $mq-medium, $mq-large);
 @include visibility(large, $mq-large);
+
+// Generates responsive visibility tags
+@each $key, $value in (
+  x-small: $mq-x-small,
+  small: $mq-small,
+  medium: $mq-medium,
+  large: $mq-large,
+  x-large: $mq-x-large,
+) {
+  @media(min-width: $value) {
+    // [EXAMPLE] hide--medium:
+    // HIDES the element when window is BIGGER than medium.
+    // element will be displayed normaly when window is smaller.
+    .hide--#{$key} { display: none; }
+  }
+
+  @media(max-width: $value - 1px) {
+    // [EXAMPLE] show--medium:
+    // HIDES the element when window is SMALLER than medium.
+    // element will be displayed normaly when window is bigger.
+    .show--#{$key} { display: none; }
+  }
+}

--- a/ui/utilities/visibility/flavors/responsive/_index.scss
+++ b/ui/utilities/visibility/flavors/responsive/_index.scss
@@ -28,7 +28,7 @@
     // element will be displayed normaly when window is smaller.
     .slds-hide--#{$key} {
       // !important is required to increase specificity
-      display: none!important;
+      display: none !important;
     }
   }
 
@@ -38,7 +38,7 @@
     // element will be displayed normaly when window is bigger.
     .slds-show--#{$key} {
       // !important is required to increase specificity
-      display: none!important;
+      display: none !important;
     }
   }
 }

--- a/ui/utilities/visibility/flavors/responsive/_index.scss
+++ b/ui/utilities/visibility/flavors/responsive/_index.scss
@@ -26,13 +26,17 @@
     // [EXAMPLE] slds-hide--medium:
     // HIDES the element when window is BIGGER than medium.
     // element will be displayed normaly when window is smaller.
-    .slds-hide--#{$key} { display: none; }
+    .slds-hide--#{$key} {
+      display: none;
+    }
   }
 
   @media(max-width: $value - 1px) {
     // [EXAMPLE] slds-show--medium:
     // HIDES the element when window is SMALLER than medium.
     // element will be displayed normaly when window is bigger.
-    .slds-show--#{$key} { display: none; }
+    .slds-show--#{$key} {
+      display: none;
+    }
   }
 }

--- a/ui/utilities/visibility/flavors/responsive/index.markup.md
+++ b/ui/utilities/visibility/flavors/responsive/index.markup.md
@@ -1,4 +1,7 @@
-<p>Responsive visibility classes will show and hide content on specific breakpoints. By default, <code>-show</code> renders as <code>display: block;</code>, but you may pass through a display property of your choice by adding a modifier to the end of the classname. For example, you may need to render an element as <code>display: inline-block</code> at a medium breakpoint, adding <code>--inline-block</code> to the end of <code>.slds-medium-show</code> to produce the class of <code>.slds-medium-show--inline-block</code> will give you that outcome.</p>
+<p>Responsive visibility classes will HIDE content on specific breakpoints.
+<code>slds-show--[breakpoint]</code> renders <code>display: none;</code> when the the view port width is smaller than the breakpoint, and do nothing if it is bigger or equal.
+<code>slds-hide--[breakpoint]</code> does the oposite by rendering <code>display: none;</code> when the the view port width is bigger or equal than the breakpoint, and do nothing if it is smaller.
+</p>
 
 <div class="demo-visibility-chart slds-m-bottom--large">
   <div class="slds-scrollable--x">
@@ -30,7 +33,6 @@
         <td class="visible">Show</td>
         <td class="visible">Show</td>
       </tr>
-
       <tr>
         <th><code>.slds-hide--small</code></th>
         <td class="visible">Show</td>
@@ -49,7 +51,6 @@
         <td class="visible">Show</td>
         <td class="visible">Show</td>
       </tr>
-
       <tr>
         <th><code>.slds-hide--medium</code></th>
         <td class="visible">Show</td>
@@ -68,7 +69,6 @@
         <td class="visible">Show</td>
         <td class="visible">Show</td>
       </tr>
-
       <tr>
         <th><code>.slds-hide--large</code></th>
         <td class="visible">Show</td>
@@ -87,7 +87,6 @@
         <td class="visible">Show</td>
         <td class="visible">Show</td>
       </tr>
-
       <tr>
         <th><code>.slds-hide--x-large</code></th>
         <td class="visible">Show</td>

--- a/ui/utilities/visibility/flavors/responsive/index.markup.md
+++ b/ui/utilities/visibility/flavors/responsive/index.markup.md
@@ -6,51 +6,34 @@
       <tr class="site-text-heading--label">
         <th scope="col"><span class="slds-assistive-text">Class Name</span></th>
         <th scope="col">Less than 320px</th>
-        <th scope="col">X-Small (320px)</th>
-        <th scope="col">Small (480px)</th>
-        <th scope="col">Medium (768px)</th>
-        <th scope="col">Large (1024px)</th>
-        <th scope="col">Greater than 1024px</th>
+        <th scope="col">X-Small (>= 320px)</th>
+        <th scope="col">Small (>= 480px)</th>
+        <th scope="col">Medium (>= 768px)</th>
+        <th scope="col">Large (>= 1024px)</th>
+        <th scope="col">X-Large (>= 1280px)</th>
       </tr>
       <tr>
-        <th><code>.slds-x-small-show</code></th>
+        <th><code>.slds-hide--x-small</code></th>
+        <td class="visible">Show</td>
         <td class="hidden">Hide</td>
-        <td class="visible">Show</td>
-        <td class="visible">Show</td>
-        <td class="visible">Show</td>
-        <td class="visible">Show</td>
-        <td class="visible">Show</td>
+        <td class="hidden">Hide</td>
+        <td class="hidden">Hide</td>
+        <td class="hidden">Hide</td>
+        <td class="hidden">Hide</td>
       </tr>
       <tr>
-        <th><code>.slds-small-show</code></th>
-        <td class="hidden">Hide</td>
+        <th><code>.slds-show--x-small</code></th>
         <td class="hidden">Hide</td>
         <td class="visible">Show</td>
         <td class="visible">Show</td>
-        <td class="visible">Show</td>
-        <td class="visible">Show</td>
-      </tr>
-      <tr>
-        <th><code>.slds-medium-show</code></th>
-        <td class="hidden">Hide</td>
-        <td class="hidden">Hide</td>
-        <td class="hidden">Hide</td>
         <td class="visible">Show</td>
         <td class="visible">Show</td>
         <td class="visible">Show</td>
       </tr>
+
       <tr>
-        <th><code>.slds-large-show</code></th>
-        <td class="hidden">Hide</td>
-        <td class="hidden">Hide</td>
-        <td class="hidden">Hide</td>
-        <td class="hidden">Hide</td>
+        <th><code>.slds-hide--small</code></th>
         <td class="visible">Show</td>
-        <td class="visible">Show</td>
-      </tr>
-      <tr>
-        <th><code>.slds-x-small-show-only</code></th>
-        <td class="hidden">Hide</td>
         <td class="visible">Show</td>
         <td class="hidden">Hide</td>
         <td class="hidden">Hide</td>
@@ -58,49 +41,70 @@
         <td class="hidden">Hide</td>
       </tr>
       <tr>
-        <th><code>.slds-small-show-only</code></th>
+        <th><code>.slds-show--small</code></th>
         <td class="hidden">Hide</td>
         <td class="hidden">Hide</td>
+        <td class="visible">Show</td>
+        <td class="visible">Show</td>
+        <td class="visible">Show</td>
+        <td class="visible">Show</td>
+      </tr>
+
+      <tr>
+        <th><code>.slds-hide--medium</code></th>
+        <td class="visible">Show</td>
+        <td class="visible">Show</td>
         <td class="visible">Show</td>
         <td class="hidden">Hide</td>
         <td class="hidden">Hide</td>
         <td class="hidden">Hide</td>
       </tr>
       <tr>
-        <th><code>.slds-medium-show-only</code></th>
+        <th><code>.slds-show--medium</code></th>
         <td class="hidden">Hide</td>
         <td class="hidden">Hide</td>
         <td class="hidden">Hide</td>
+        <td class="visible">Show</td>
+        <td class="visible">Show</td>
+        <td class="visible">Show</td>
+      </tr>
+
+      <tr>
+        <th><code>.slds-hide--large</code></th>
+        <td class="visible">Show</td>
+        <td class="visible">Show</td>
+        <td class="visible">Show</td>
         <td class="visible">Show</td>
         <td class="hidden">Hide</td>
         <td class="hidden">Hide</td>
       </tr>
       <tr>
-        <th><code>.slds-max-x-small-hide</code></th>
+        <th><code>.slds-show--large</code></th>
         <td class="hidden">Hide</td>
-        <td class="visible">Initial</td>
-        <td class="visible">Initial</td>
-        <td class="visible">Initial</td>
-        <td class="visible">Initial</td>
-        <td class="visible">Initial</td>
+        <td class="hidden">Hide</td>
+        <td class="hidden">Hide</td>
+        <td class="hidden">Hide</td>
+        <td class="visible">Show</td>
+        <td class="visible">Show</td>
+      </tr>
+
+      <tr>
+        <th><code>.slds-hide--x-large</code></th>
+        <td class="visible">Show</td>
+        <td class="visible">Show</td>
+        <td class="visible">Show</td>
+        <td class="visible">Show</td>
+        <td class="visible">Show</td>
+        <td class="hidden">Hide</td>
       </tr>
       <tr>
-        <th><code>.slds-max-small-hide</code></th>
-        <td class="hidden">Hide</td>
-        <td class="hidden">Hide</td>
-        <td class="visible">Initial</td>
-        <td class="visible">Initial</td>
-        <td class="visible">Initial</td>
-        <td class="visible">Initial</td>
-      </tr>
-      <tr>
-        <th><code>.slds-max-medium-hide</code></th>
+        <th><code>.slds-show--x-large</code></th>
         <td class="hidden">Hide</td>
         <td class="hidden">Hide</td>
         <td class="hidden">Hide</td>
-        <td class="visible">Initial</td>
-        <td class="visible">Initial</td>
-        <td class="visible">Initial</td>
+        <td class="hidden">Hide</td>
+        <td class="hidden">Hide</td>
+        <td class="visible">Show</td>
       </tr>
     </table>
   </div>

--- a/ui/utilities/visibility/flavors/responsive/index.react.example.jsx
+++ b/ui/utilities/visibility/flavors/responsive/index.react.example.jsx
@@ -15,18 +15,19 @@ import CodeClass from 'app_modules/site/components/code-class';
 
 export default (
   <div className="demo-only demo-visibility">
-    <div className="slds-x-small-show">Show on 320px and up</div>
-    <div className="slds-x-small-show-only">Show only between 320px and 479px</div>
-    <div className="slds-max-x-small-hide">Hide on 319px and down</div>
+    <div className="slds-show--x-small">Hides on 319px and down</div>
+    <div className="slds-hide--x-small">Hides on 320px and up</div>
 
-    <div className="slds-small-show">Show on 480px and up</div>
-    <div className="slds-small-show-only">Show only between 480px and 767px</div>
-    <div className="slds-max-small-hide">Hide on 479px and down</div>
+    <div className="slds-show--small">Hides on 479px and down</div>
+    <div className="slds-hide--small">Hides on 480px and up</div>
 
-    <div className="slds-medium-show">Show on 768px and up</div>
-    <div className="slds-medium-show-only">Show only between 768px and 1023px</div>
-    <div className="slds-max-medium-hide">Hide on 1023px and down</div>
+    <div className="slds-show--medium">Hides on 767px and down</div>
+    <div className="slds-hide--medium">Hides on 768px and up</div>
 
-    <div className="slds-large-show">Show on 1024px and up</div>
+    <div className="slds-show--large">Hides on 1023px and down</div>
+    <div className="slds-hide--large">Hides on 1024px and up</div>
+
+    <div className="slds-show--x-large">Hides on 1279px and down</div>
+    <div className="slds-hide--x-large">Hides on 1280px and up</div>
   </div>
 );


### PR DESCRIPTION
This PR adds visibility classes that: 

* Do not mess up with the grid, by using only display: none.
* Can be used to HIDE elements when widow is SMALLER than a given breakpoint. e.g `slds-show--medium`
* Can be used to HIDE elements when widow is BIGGER (or equal) than a given breakpoint. e.g `slds-hide--medium`.

Issues: #427, #263, #292, #48

### Example

```html
<header>
  <nav class="slds-hide--medium">
    navbar for MOBILE, will be visible when window is smaller than medium
  </nav>
  
  <nav class="slds-show--medim slds-hide--x-large">
     navbar for DESKTOP, will be visible when window is bigger (or equal) than medium,
     but it will be hidden when it is window is x-large
  </nav>

  <nav class="slds-show--x-large">
     navbar for a VERY LARGE display, will be visible when window is bigger than x-large
  </nav>
</header>
```

### Reviewer, please refer to this "definition of done" checklist:

* [x] Tested on **desktop** (see [supported browsers](https://www.lightningdesignsystem.com/faq/#what-browsers-are-supported))
* [x] Tested on **mobile** (for responsive or mobile-specific features)
* [x] Confirm **Accessibility**
* [x] Documentation is up to date
* [x] Release notes mention the changes

⚠️ Once this pull request is merged, please merge the code into other development branches:
[Merge branch 'winter-17' into spring-17](http://bit.ly/28OZIGM)
[Merge branch 'spring-17' into summer-17](http://bit.ly/2fjT4LY)
