### PR TITLE
Fix #442 - Remove :after for disabled checkbox

### DIFF
--- a/ui/components/forms/flavors/checkbox/_index.scss
+++ b/ui/components/forms/flavors/checkbox/_index.scss
@@ -97,11 +97,6 @@
       + .slds-checkbox__label .slds-checkbox--faux {
         background-color: $color-background-input-disabled;
         border-color: $color-border-input-disabled;
-
-
-        &:after {
-          border-color: $color-background-input;
-        }
       }
     }
   }


### PR DESCRIPTION
@kaelig
@stefsullrew

Changes proposed in this pull request:

* disabled :after rule removed as it turns the checkmark white against a grey background (barely visible). Without this rule, the checkmark is left blue while the disabled checkbox remains grey background. Higher contrast/visibility.

### Reviewer, please refer to this "definition of done" checklist:

* [ ] Tested on **desktop** (see [supported browsers](https://www.lightningdesignsystem.com/faq/#what-browsers-are-supported))
* [ ] Tested on **mobile** (for responsive or mobile-specific features)
* [ ] Confirm **Accessibility**
* [ ] Documentation is up to date
* [ ] Release notes mention the changes

⚠️ Once this pull request is merged, please merge the code into other development branches:
[Merge branch 'winter-17' into spring-17](http://bit.ly/28OZIGM)
[Merge branch 'spring-17' into summer-17](http://bit.ly/2fjT4LY)
