### PR TITLE
Fix .slds-item for .slds-post__footer-action

### DIFF
--- a/ui/components/feeds/post/_index.scss
+++ b/ui/components/feeds/post/_index.scss
@@ -88,6 +88,15 @@
   justify-content: space-between;
   text-align: center;
   order: 1;
+  
+  .slds-item {
+    display: flex;
+    justify-content: center;
+    
+    @include mq-medium-max {
+      margin-right: 0;
+    }
+  }
 
   @include mq-small-max {
     border-top: $border-width-thin solid $color-border;

--- a/ui/components/feeds/post/_index.scss
+++ b/ui/components/feeds/post/_index.scss
@@ -88,11 +88,11 @@
   justify-content: space-between;
   text-align: center;
   order: 1;
-  
+
   .slds-item {
     display: flex;
     justify-content: center;
-    
+
     @include mq-medium-max {
       margin-right: 0;
     }


### PR DESCRIPTION
Fix .slds-item for .slds-post__footer-action to center button in space when viewport is medium

```css
.slds-post__footer-actions-list .slds-item {
  display: flex;
  justify-content: center;
}
```

Remove margin right when viewport is medium 

```css
@media (max-width: 48em) {
  .slds-post__footer-actions-list .slds-item {
    margin-right: 0;
  }
}
```

<!--
NOTE: Please make site changes for summer-17/winter-18 directly on the new site's repository.
      Pull requests that don't follow this rule will get closed.
-->

Changes proposed in this pull request:

* Center buttons when viewport is medium and remove margin-right

### Reviewer, please refer to this "definition of done" checklist:

* [x] Tested on **desktop** (see [supported browsers](https://www.lightningdesignsystem.com/faq/#what-browsers-are-supported))
* [x] Tested on **mobile** (for responsive or mobile-specific features)
* [x] Confirm **Accessibility**
* [x] Documentation is up to date
* [ ] Release notes mention the changes

⚠️ Once this pull request is merged, please merge the code into other development branches:
[Merge branch 'spring-17' into summer-17](http://bit.ly/2fjT4LY)
[Merge branch 'summer-17' into winter-18](http://bit.ly/2mbKAbV)