### PR TITLE
Fix disabled invalid input background color

### DIFF
--- a/ui/dependencies/_forms.scss
+++ b/ui/dependencies/_forms.scss
@@ -60,6 +60,9 @@
       &:active {
         box-shadow: $color-border-error 0 0 0 $border-width-thin inset, $shadow-button-focus;
       }
+      &:disabled {
+        border-color: $color-border-input-disabled;
+      }
     }
   }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/17860864/32203821-f83a36a2-bda2-11e7-9284-75ed2ada8f61.png)

Disabled invalid fields look like you can type into them.
Fixes disabled invalid input background color to look more consistant to disabled fields.

### Reviewer, please refer to this "definition of done" checklist:

* [ ] Tested on **desktop** (see [supported browsers](https://www.lightningdesignsystem.com/faq/#what-browsers-are-supported))
* [ ] Tested on **mobile** (for responsive or mobile-specific features)
* [ ] Confirm **Accessibility**
* [ ] Documentation is up to date
* [ ] Release notes mention the changes

⚠️ Once this pull request is merged, please merge the code into other development branches:
[Merge branch 'spring-17' into summer-17](http://bit.ly/2fjT4LY)
[Merge branch 'summer-17' into winter-18](http://bit.ly/2mbKAbV)
