### PR TITLE
Fixes typos in documentation

### DIFF
--- a/ui/components/publishers/comment/_index.scss
+++ b/ui/components/publishers/comment/_index.scss
@@ -3,13 +3,13 @@
 
 /**
  * The comment publisher is found at the bottom of a discussion feed comment
- * thread. It contains basic publishing capibilities.
+ * thread. It contains basic publishing capabilities.
  *
  * The comment publisher is in a collapsed state by default. There are 4 states
  * of the discussion feed that provide different feedback to the user. First,
  * the collapsed state, this indicates the user has not interacted with the
  * comment publisher. When the user initiates an interaction with the publisher,
- * by either focusing of the textara or clicking the "Comment" button, through
+ * by either focusing of the textarea or clicking the "Comment" button, through
  * javascript the class of `slds-is-active` should be applied to the
  * `slds-publisher` element. This class will expand the publisher box and
  * display additional publisher actions.


### PR DESCRIPTION
Please refer to our [Commit Guidelines](https://github.com/salesforce-ux/design-system-internal/blob/spring-19/CONTRIBUTING.md#commit-guidelines) for documenting changes.

**Changes proposed in this pull request:**

* Fixes typos in the documentation for `Publishers`

### Acceptance Criteria

#### General

* [ ] Tested on **desktop** (see [supported browsers](https://www.lightningdesignsystem.com/faq/#what-browsers-are-supported))
* [ ] Tested on **mobile** (for responsive or mobile-specific features)
* [ ] Confirm **Accessibility**

#### Feature

* [ ] Reference User Story work item number in description
* [ ] Add usage examples
* [ ] Add documentation for new usage guidelines
* [ ] Add tests to test new components and implementation usage
* [ ] Add component specific Release notes mentioning the changes
* [ ] If feature requires the implementor to move to a new version, please provide a migration description in the component specific Release notes

#### Fix

* [ ] Reference Bug work item number in description
* [ ] Add tests to ensure bug does not happen again
* [ ] Add component specific Release notes mentioning the changes

#### Design Changes

* [ ] Add component specific Release notes mentioning the changes
* [ ] If change requires the implementor to move to a new version, please provide a migration description in the component specific Release notes

#### Deprecated

* [ ] If css selector is being deprecated, apply the `@deprecate` annotation to selector comment block


  > ```css
  >  /**
  >   * @selector .slds-bar
  >   * @deprecated
  >   */
  >  .slds-bar { ... }
  > ```

* [ ] If css selector is being deprecated, move deprecated code to `_deprecate.scss` file and wrap in `deprecate` mixin.
* [ ] Provide `deprecate` mixin with version code will become deprecated and a brief description for what the code is being deprecated for.

  > ```css
  >  @include deprecate('4.0.0', 'Please use slds-foo instead of slds-bar') {
  >     .slds-bar { ... }
  >  }
  > ```
