### PR TITLE
chore(documentation): change links to relative

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-Please refer to our [Commit Guidelines](https://github.com/salesforce-ux/design-system-internal/blob/spring-19/CONTRIBUTING.md#commit-guidelines) for documenting changes.
+Please refer to our [Commit Guidelines](guidelines/COMMIT_GUIDELINES.md) for documenting changes.
 
 **Changes proposed in this pull request:**
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Once the development server is started with `npm start`, you can load it at [htt
 
 ### Annotations
 
-See the [annotations guide](https://github.com/salesforce-ux/design-system-internal/blob/226-summer-20/guidelines/ANNOTATIONS.md).
+See the [annotations guide](guidelines/ANNOTATIONS.md).
 
 ## Tasks
 
@@ -105,11 +105,11 @@ Delete temporary build and local files.
 
 ## Troubleshooting
 
-See the [troubleshooting guide](https://github.com/salesforce-ux/design-system-internal/blob/226-summer-20/guidelines/TROUBLESHOOTING.md).
+See the [troubleshooting guide](guidelines/TROUBLESHOOTING.md).
 
 ## Contributing Back to SLDS
 
-See the [contributing guide](https://github.com/salesforce-ux/design-system-internal/blob/226-summer-20/CONTRIBUTING.md).
+See the [contributing guide](CONTRIBUTING.md).
 
 ## Licenses
 

--- a/guidelines/ANNOTATIONS_FULL.md
+++ b/guidelines/ANNOTATIONS_FULL.md
@@ -56,7 +56,7 @@ Here is an example of how that may look.
 }
 ```
 
-[See classname annotations](https://github.com/salesforce-ux/design-system-internal/wiki/Documentation-Styleguide#selector-annotations)
+[See selector annotations](#selector-annotations)
 
 # Component Annotations
 
@@ -355,7 +355,7 @@ For utility annotations, we only need a way to map HTML to the classnames, this 
 
 We annotate a utility by using an `@utility` identifier and a universal selector, which acts as a catch all for utilities starting with the name of that utility, for example spacing utilities have a naming pattern that starts with .`slds-m-` where we can append a direction name and a size name. The universal selector would restrict the prefix of `.slds-m-` to all margin related spacing classes.
 
-## Selector Annotations
+# Selector Annotations
 
 The selector annotations are used to document the classname and establish its restriction rules with the `@restrict` annotation. The annotations should be added to the `_index.scss` where you have written your css declarations. The annotation block should come before each selector declaration. For example:
 


### PR DESCRIPTION
**Changes proposed in this pull request:**

* I found a few places that links in `.md` files pointed to private Salesforce locations, resulting in 404s for the public. These links have been set to relative now.

### Acceptance Criteria

#### General

* [ ] Tested on **desktop** (see [supported browsers](https://www.lightningdesignsystem.com/faq/#what-browsers-are-supported))
* [ ] Tested on **mobile** (for responsive or mobile-specific features)
* [ ] Confirm **Accessibility**

#### Feature

* [ ] Reference User Story work item number in description
* [ ] Add usage examples
* [ ] Add documentation for new usage guidelines
* [ ] Add tests to test new components and implementation usage
* [ ] Add component specific Release notes mentioning the changes
* [ ] If feature requires the implementor to move to a new version, please provide a migration description in the component specific Release notes

#### Fix

* [ ] Reference Bug work item number in description
* [ ] Add tests to ensure bug does not happen again
* [ ] Add component specific Release notes mentioning the changes

#### Design Changes

* [ ] Add component specific Release notes mentioning the changes
* [ ] If change requires the implementor to move to a new version, please provide a migration description in the component specific Release notes

#### Deprecated

* [ ] If css selector is being deprecated, apply the `@deprecate` annotation to selector comment block


  > ```css
  >  /**
  >   * @selector .slds-bar
  >   * @deprecated
  >   */
  >  .slds-bar { ... }
  > ```

* [ ] If css selector is being deprecated, move deprecated code to `_deprecate.scss` file and wrap in `deprecate` mixin.
* [ ] Provide `deprecate` mixin with version code will become deprecated and a brief description for what the code is being deprecated for.

  > ```css
  >  @include deprecate('4.0.0', 'Please use slds-foo instead of slds-bar') {
  >     .slds-bar { ... }
  >  }
  > ```
