### PR TITLE
fix: update lwc module resolution configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -263,6 +263,9 @@
         "name": "@salesforce/slds/legacy",
         "path": "assets/styles/salesforce-lightning-design-system-imports.sanitized.css"
       }
+    ],
+    "expose": [
+      "@salesforce/slds/legacy"
     ]
   }
 }


### PR DESCRIPTION
**Changes proposed in this pull request:**

The @lwc/module-resolver requires package configuration to explicitly expose modules
https://rfcs.lwc.dev/rfcs/lwc/0020-module-resolution#exposing-modules
This PR updates the config.

W-7470099

#### Fix

* [x] Reference Bug work item number in description
* [ ] Add tests to ensure bug does not happen again
* [ ] Add component specific Release notes mentioning the changes


