### PR TITLE
build: fix SassError: Undefined operation

### DIFF
--- a/ui/components/accordion/base/_index.scss
+++ b/ui/components/accordion/base/_index.scss
@@ -39,19 +39,19 @@
   margin-top: calc(
     var(--slds-c-accordion-section-spacing-block-start,
     var(--sds-c-accordion-section-spacing-block-start,
-    #{$spacing-small} * -1)));
+    -#{$spacing-small})));
   margin-right: calc(
     var(--slds-c-accordion-section-spacing-inline-end,
     var(--sds-c-accordion-section-spacing-inline-end,
-    #{$spacing-small} * -1)));
+    -#{$spacing-small})));
   margin-bottom: calc(
     var(--slds-c-accordion-section-spacing-block-end,
     var(--sds-c-accordion-section-spacing-block-end,
-    #{$spacing-small} * -1)));
+    -#{$spacing-small})));
   margin-left: calc(
     var(--slds-c-accordion-section-spacing-inline-start,
     var(--sds-c-accordion-section-spacing-inline-start,
-    #{$spacing-small} * -1)));
+    -#{$spacing-small})));
   padding-top: var(--slds-c-accordion-section-spacing-block-start, var(--sds-c-accordion-section-spacing-block-start, #{$spacing-small}));
   padding-right: var(--slds-c-accordion-section-spacing-inline-end, var(--sds-c-accordion-section-spacing-inline-end, #{$spacing-small}));
   padding-bottom: var(--slds-c-accordion-section-spacing-block-end, var(--sds-c-accordion-section-spacing-block-end, #{$spacing-small}));
@@ -91,19 +91,19 @@
   margin-top: calc(
     var(--slds-c-accordion-section-spacing-block-start,
     var(--sds-c-accordion-section-spacing-block-start,
-    #{$spacing-small} * -1)));
+    -#{$spacing-small})));
   margin-right: calc(
     var(--slds-c-accordion-section-spacing-inline-end,
     var(--sds-c-accordion-section-spacing-inline-end,
-    #{$spacing-small} * -1)));
+    -#{$spacing-small})));
   margin-bottom: calc(
     var(--slds-c-accordion-section-spacing-block-end,
     var(--sds-c-accordion-section-spacing-block-end,
-    #{$spacing-small} * -1)));
+    -#{$spacing-small})));
   margin-left: calc(
     var(--slds-c-accordion-section-spacing-inline-start,
     var(--sds-c-accordion-section-spacing-inline-start,
-    #{$spacing-small} * -1)));
+    -#{$spacing-small})));
   padding-top: var(--slds-c-accordion-section-spacing-block-start, var(--sds-c-accordion-section-spacing-block-start, $spacing-small));
   padding-right: var(--slds-c-accordion-section-spacing-inline-end, var(--sds-c-accordion-section-spacing-inline-end, $spacing-small));
   padding-bottom: var(--slds-c-accordion-section-spacing-block-end, var(--sds-c-accordion-section-spacing-block-end, $spacing-small));


### PR DESCRIPTION
Fixed SASS issue during a build process.
```
SassError: SassError: Undefined operation "0.75rem * -1".
   │
   │     #{$spacing-small} * -1)));
   │     ^^^^^^^^^^^^^^^^^^^^^^
```

I'm getting this error trying to build `.scss` files.

```sass
// slds.scss
@import "@salesforce-ux/design-system/scss";
```

Here is the list of installed dependencies.

```json
{
  "devDependencies": {
      "sass": "^1.49.9",
      "sass-loader": "^12.6.0",
      "webpack": "^5.70.0"
  }
}
```

**Changes proposed in this pull request:**

* Instead of performing -1 multiplication, let's just prepend minus sign to a value.

### Acceptance Criteria

#### General

* [ ] Tested on **desktop** (see [supported browsers](https://www.lightningdesignsystem.com/faq/#what-browsers-are-supported))
* [ ] Tested on **mobile** (for responsive or mobile-specific features)
* [ ] Confirm **Accessibility**
* [ ] Confirm **RTL**

#### Feature

* [ ] Reference User Story work item number in description
* [ ] Add usage examples
* [ ] Add documentation for new usage guidelines
* [ ] Add tests to test new components and implementation usage
* [ ] Add component specific Release notes mentioning the changes
* [ ] If feature requires the implementor to move to a new version, please provide a migration description in the component specific Release notes

#### Fix

* [ ] Reference Bug work item number in description
* [ ] Add tests to ensure bug does not happen again
* [ ] Add component specific Release notes mentioning the changes

#### Design Changes

* [ ] Add component specific Release notes mentioning the changes
* [ ] If change requires the implementor to move to a new version, please provide a migration description in the component specific Release notes

#### Deprecated

* [ ] If css selector is being deprecated, apply the `@deprecate` annotation to selector comment block


  > ```css
  >  /**
  >   * @selector .slds-bar
  >   * @deprecated
  >   */
  >  .slds-bar { ... }
  > ```

* [ ] If css selector is being deprecated, move deprecated code to `_deprecate.scss` file and wrap in `deprecate` mixin.
* [ ] Provide `deprecate` mixin with version code will become deprecated and a brief description for what the code is being deprecated for.

  > ```css
  >  @include deprecate('4.0.0', 'Please use slds-foo instead of slds-bar') {
  >     .slds-bar { ... }
  >  }
  > ```
