### PR TITLE
docs(vertical-navigation): correct icon class

### DIFF
--- a/ui/components/vertical-navigation/quickfind/example.jsx
+++ b/ui/components/vertical-navigation/quickfind/example.jsx
@@ -30,7 +30,7 @@ export default [
             hasHiddenLabel
           >
             <SvgIcon
-              className="slds-icon slds-input__icon slds-input__icon_right slds-icon-text-default"
+              className="slds-icon slds-input__icon slds-input__icon_left slds-icon-text-default"
               sprite="utility"
               symbol="search"
             />


### PR DESCRIPTION
Icon class should be `slds-input__icon_left` not `slds-input__icon_right`