### PR TITLE
docs(modals): focusable header

### DIFF
--- a/ui/components/modals/base/example.jsx
+++ b/ui/components/modals/base/example.jsx
@@ -268,7 +268,7 @@ export let Footless = (props) => (
   <Backdrop>
     <Modal aria-labelledby="modal-heading-01">
       <ModalHeader>
-        <h1 id="modal-heading-01" className="slds-modal__title slds-hyphenate">
+        <h1 id="modal-heading-01" className="slds-modal__title slds-hyphenate" tabindex="-1">
           Modal header
         </h1>
       </ModalHeader>


### PR DESCRIPTION
There is a statement in the docs.

> If no interactive element exists to set focus when the modal opens, add the appropriate tabindex attribute to the header to allow for programmatic focus (see "Footless" example, below).

But the header in "Footless" example isn't focusable.