### PR TITLE
fix(button): change text hover color

### DIFF
--- a/ui/components/buttons/dual-stateful/_index.scss
+++ b/ui/components/buttons/dual-stateful/_index.scss
@@ -81,7 +81,7 @@
       var(--sds-c-button-brand-color-border-hover, #{$brand-accessible-active})));
 
     /*! @css-var-fallback color */
-    --slds-c-button-dual-stateful-text-color-selected:
+    --slds-c-button-text-color-hover:
       var(--slds-c-button-dual-stateful-text-color-selected-hover,
       var(--slds-c-button-brand-text-color-hover,
       var(--sds-c-button-brand-text-color-hover, #{$color-text-brand-primary})));


### PR DESCRIPTION
When button is hovered in [Dual Stateful Button Pressed](https://www.lightningdesignsystem.com/components/buttons/#Pressed) example its text becomes completely unreadable.

<img width="124" alt="Following button" src="https://user-images.githubusercontent.com/44983823/177870360-8020f4e7-6a58-490f-9b18-575a468ea52d.png"> <img width="124" alt="Following button with unreadable text" src="https://user-images.githubusercontent.com/44983823/177870602-47eb1ff3-3010-4aac-b4d9-baa9aa463fd3.png">

This PR is intended to fix the issue, but I'm not sure I did it the right way.

