### PR TITLE
docs(progress-bar): add success color example

### DIFF
--- a/ui/components/progress-bar/base/example.jsx
+++ b/ui/components/progress-bar/base/example.jsx
@@ -79,7 +79,7 @@ export let examples = [
   {
     id: 'success',
     label: 'Success',
-    element: <ProgressBar isSuccess value="75" />
+    element: <ProgressBar isSuccess value="100" />
   },
   {
     id: 'circular',

--- a/ui/components/progress-bar/docs.mdx
+++ b/ui/components/progress-bar/docs.mdx
@@ -101,6 +101,14 @@ import * as Vertical from './vertical/example';
 
 ## Modifiers
 
+### Colors
+
+#### Success
+
+<CodeView>
+  {getDisplayElementById(Base.examples, 'success')}
+</CodeView>
+
 ### Radius
 <CodeView>
   {getDisplayElementById(Base.examples, 'circular')}


### PR DESCRIPTION
There is `.slds-progress-bar__value_success` class in [Overview of CSS Classes](https://www.lightningdesignsystem.com/components/progress-bar/#CSS-Class-Overview). It would be great to add an example demonstrating this class usage.