### PR TITLE
Fixing typo in Documentation in Icons

### DIFF
--- a/ui/components/icons/docs.mdx
+++ b/ui/components/icons/docs.mdx
@@ -129,7 +129,7 @@ To change the fill of an icon to match the current color of its parent, add the 
 To change the fill of an icon to the success text color, add the `slds-icon-text-success` class to the icon.
 
 <CodeView>
-  {getDisplayElementById(UtilityIconExamples.examples, 'text-warning')}
+  {getDisplayElementById(UtilityIconExamples.examples, 'text-success')}
 </CodeView>
 
 ### Warning


### PR DESCRIPTION
Hi,

I open pull request to fix this typo as mentioned on #735 

I did not go through all recommended checks for pull request, because I think this is just a typo in documentation file.

Hope it works!