### PR TITLE
fix: fix typo in $_sizes map

### DIFF
--- a/ui/utilities/sizing/_index.scss
+++ b/ui/utilities/sizing/_index.scss
@@ -5,7 +5,7 @@
 /// @type map
 /// @private
 $_sizes: (
-  'xxx-small,': $size-xxx-small,
+  'xxx-small': $size-xxx-small,
   'xx-small': $size-xx-small,
   'x-small': $size-x-small,
   'small': $size-small,


### PR DESCRIPTION
**Changes proposed in this pull request:**

There appears to be a typo in this file: an extra `,`. I believe this was unintentional.

Fortunately, this extra comma doesn't actually affect the output CSS, as SASS intelligently removes empty selectors in a list:

![Screen Shot 2023-01-31 at 8 59 47 AM](https://user-images.githubusercontent.com/283842/215830891-c56fe97c-c5d1-48f5-b311-601e39a36313.png)

… and this variable just happens to be used in such a way that it only creates empty selectors.

I verified that the output file `assets/styles/index.css` is exactly the same before and after.

### Acceptance Criteria

#### General

* [ ] Tested on **desktop** (see [supported browsers](https://www.lightningdesignsystem.com/faq/#what-browsers-are-supported))
* [ ] Tested on **mobile** (for responsive or mobile-specific features)
* [ ] Confirm **Accessibility**
* [ ] Confirm **RTL**

#### Feature

* [ ] Reference User Story work item number in description
* [ ] Add usage examples
* [ ] Add documentation for new usage guidelines
* [ ] Add tests to test new components and implementation usage
* [ ] Add component specific Release notes mentioning the changes
* [ ] If feature requires the implementor to move to a new version, please provide a migration description in the component specific Release notes

#### Fix

* [ ] Reference Bug work item number in description
* [ ] Add tests to ensure bug does not happen again
* [ ] Add component specific Release notes mentioning the changes

#### Design Changes

* [ ] Add component specific Release notes mentioning the changes
* [ ] If change requires the implementor to move to a new version, please provide a migration description in the component specific Release notes

#### Deprecated

* [ ] If css selector is being deprecated, apply the `@deprecate` annotation to selector comment block


  > ```css
  >  /**
  >   * @selector .slds-bar
  >   * @deprecated
  >   */
  >  .slds-bar { ... }
  > ```

* [ ] If css selector is being deprecated, move deprecated code to `_deprecate.scss` file and wrap in `deprecate` mixin.
* [ ] Provide `deprecate` mixin with version code will become deprecated and a brief description for what the code is being deprecated for.

  > ```css
  >  @include deprecate('4.0.0', 'Please use slds-foo instead of slds-bar') {
  >     .slds-bar { ... }
  >  }
  > ```
