### PR TITLE
docs: remove duplicate 'the' in ANNOTATIONS.md

### DIFF
--- a/guidelines/ANNOTATIONS.md
+++ b/guidelines/ANNOTATIONS.md
@@ -26,7 +26,7 @@ For example:
 
 In this example we can see that `.slds-button_brand` must be applied to a `.slds-button`, which, in turn, must be applied to a `button, a, span`.
 
-It's important to know that `slds-button_brand` will only be associated to the button component via this `@restrict` chain. Each rule uses its `@restrict` to declare its place in the hierarchy - **it is not the the file that tells us to which component a selector belongs**
+It's important to know that `slds-button_brand` will only be associated to the button component via this `@restrict` chain. Each rule uses its `@restrict` to declare its place in the hierarchy - **it is not the file that tells us to which component a selector belongs**
 
 For a more complex example, see: https://github.com/salesforce-ux/design-system/blob/master/ui/components/combobox/base/_index.scss
 


### PR DESCRIPTION
Tiny typo fix: 'it is not the the file' → 'it is not the file'.